### PR TITLE
Prefactoring before adding metrics support.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/go.sum       linguist-generated=true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,11 +47,12 @@ jobs:
 
       - name: Prepare manifests for linting
         run: |
+          go build -C deploy .
           mkdir manifests
-          go run deploy/main.go my-images v0.0.8 vanilla > manifests/vanilla.yaml
-          go run deploy/main.go my-images v0.0.8 ocp > manifests/ocp.yaml
-          go run deploy/main.go my-images v0.0.8 vanilla my-secret > manifests/vanilla-with-secret.yaml
-          go run deploy/main.go my-images v0.0.8 ocp my-secret > manifests/ocp-with-secret.yaml
+          ./deploy/deploy --k8s-flavor vanilla my-images > manifests/vanilla.yaml
+          ./deploy/deploy --k8s-flavor ocp my-images > manifests/ocp.yaml
+          ./deploy/deploy --k8s-flavor vanilla --secret my-secret my-images > manifests/vanilla-with-secret.yaml
+          ./deploy/deploy --k8s-flavor ocp --secret my-secret my-images > manifests/ocp-with-secret.yaml
 
       - name: kube-linter
         uses: stackrox/kube-linter-action@v1.0.5

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Talks directly to Container Runtime Interface ([CRI](https://kubernetes.io/docs/
 ### `image-prefetcher`
 
 - main binary,
-- meant to be run in pods of a DaemonSet,
 - shipped as an OCI image,
 - provides two subcommands:
-  - `fetch`: runs the actual image pulls via CRI, meant to run as an init container,
+  - `fetch`: runs the actual image pulls via CRI, meant to run as an init container
+    of DaemonSet pods.
     Requires access to the CRI UNIX domain socket from the host.
-  - `sleep`: just sleeps forever, meant to run as the main container,
+  - `sleep`: just sleeps forever, meant to run as the main container of DaemonSet pods.
 
 ### `deploy`
 
@@ -29,21 +29,22 @@ Talks directly to Container Runtime Interface ([CRI](https://kubernetes.io/docs/
 
    You can run many instances independently.
 
-   It requires a few arguments:
-   - **name** of the instance.
-     This also determines the name of a `ConfigMap` supplying names of images to fetch.
-   - `image-prefetcher` OCI image **version**. See [list of existing tags](https://quay.io/repository/mowsiany/image-prefetcher?tab=tags).
-   - **cluster flavor**. Currently one of:
+   It requires a single positional argument for the **name** of the instance.
+   This also determines the name of a `ConfigMap` supplying names of images to fetch.
+
+   It also accepts a few optional flags:
+   - `--version`: `image-prefetcher` OCI image tag. See [list of existing tags](https://quay.io/repository/mowsiany/image-prefetcher?tab=tags).
+   - `--k8s-flavor` depending on the cluster. Currently one of:
      - `vanilla`: a generic Kubernetes distribution without additional restrictions.
      - `ocp`: OpenShift, which requires explicitly granting special privileges.
-   - optional **image pull `Secret` name**. Required if the images are not pullable anonymously.
+   - `--secret`: image pull `Secret` name. Required if the images are not pullable anonymously.
      This image pull secret should be usable for all images fetched by the given instance.
      If provided, it must be of type `kubernetes.io/dockerconfigjson` and exist in the same namespace.
 
    Example:
 
    ```
-   go run github.com/stackrox/image-prefetcher/deploy@main my-images v0.0.8 vanilla > manifest.yaml
+   go run github.com/stackrox/image-prefetcher/deploy@master my-images v0.0.8 vanilla > manifest.yaml
    ```
 
 2. Prepare an image list. This should be a plain text file with one image name per line.

--- a/deploy/deployment.yaml.gotpl
+++ b/deploy/deployment.yaml.gotpl
@@ -18,8 +18,8 @@ kind: RoleBinding
 metadata:
   name: prefetcher-privileged
 subjects:
-  - kind: ServiceAccount
-    name: default
+- kind: ServiceAccount
+  name: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -48,74 +48,74 @@ spec:
       {{ end }}
     spec:
       tolerations:
-        # Broad toleration to match stackrox collector.
-        - operator: "Exists"
+      # Broad toleration to match stackrox collector.
+      - operator: "Exists"
       initContainers:
-        - name: prefetch
-          image: {{ .Image }}:{{ .Version }}
-          args:
-            - "fetch"
-            {{ if .Secret }}
-            - "--docker-config=/tmp/pull-secret/.dockerconfigjson"
-            {{ end }}
-            - "--image-list-file=/tmp/list/images.txt"
-            {{ if .IsCRIO }}
-            - "--cri-socket=/tmp/cri/crio.sock"
-            {{ else }}
-            - "--cri-socket=/tmp/cri/containerd.sock"
-            {{ end }}
-          resources:
-            requests:
-              cpu: "20m"
-              memory: "16Mi"
-            limits:
-              cpu: "1"
-              memory: "256Mi"
-          volumeMounts:
-            - name: cri-socket-dir
-              mountPath: "/tmp/cri"
-              readOnly: true
-            - name: image-list
-              mountPath: "/tmp/list"
-              readOnly: true
-            {{ if .Secret }}
-            - mountPath: /tmp/pull-secret
-              name: pull-secret
-              readOnly: true
-            {{ end }}
-          securityContext:
-            readOnlyRootFilesystem: true
+      - name: prefetch
+        image: {{ .Image }}:{{ .Version }}
+        args:
+        - "fetch"
+        {{ if .Secret }}
+        - "--docker-config=/tmp/pull-secret/.dockerconfigjson"
+        {{ end }}
+        - "--image-list-file=/tmp/list/images.txt"
+        {{ if .IsCRIO }}
+        - "--cri-socket=/tmp/cri/crio.sock"
+        {{ else }}
+        - "--cri-socket=/tmp/cri/containerd.sock"
+        {{ end }}
+        resources:
+          requests:
+            cpu: "20m"
+            memory: "16Mi"
+          limits:
+            cpu: "1"
+            memory: "256Mi"
+        volumeMounts:
+        - name: cri-socket-dir
+          mountPath: "/tmp/cri"
+          readOnly: true
+        - name: image-list
+          mountPath: "/tmp/list"
+          readOnly: true
+        {{ if .Secret }}
+        - mountPath: /tmp/pull-secret
+          name: pull-secret
+          readOnly: true
+        {{ end }}
+        securityContext:
+          readOnlyRootFilesystem: true
           {{ if .NeedsPrivileged }}
-            allowPrivilegeEscalation: true
-            privileged: true
+          allowPrivilegeEscalation: true
+          privileged: true
           {{ end }}
       containers:
-        - name: sleep
-          image: {{ .Image }}:{{ .Version }}
-          args:
-            - "sleep"
-          resources:
-            requests:
-              cpu: "5m"
-              memory: "16Mi"
-            limits:
-              cpu: "100m"
-              memory: "64Mi"
-          securityContext:
-            readOnlyRootFilesystem: true
+      - name: sleep
+        image: {{ .Image }}:{{ .Version }}
+        args:
+        - "sleep"
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "16Mi"
+          limits:
+            cpu: "100m"
+            memory: "64Mi"
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
-        - name: cri-socket-dir
-          hostPath:
-            {{ if .IsCRIO }}
-            path: "/var/run/crio"
-            {{ else }}
-            path: "/var/run/containerd"
-            {{ end }}
-        - name: image-list
-          configMap:
-            name: {{ .Name }}
-        {{ if .Secret }}
-        - name: pull-secret
-          secret:
-            secretName: {{ .Secret }}
-        {{ end }}
+      - name: cri-socket-dir
+        hostPath:
+          {{ if .IsCRIO }}
+          path: "/var/run/crio"
+          {{ else }}
+          path: "/var/run/containerd"
+          {{ end }}
+      - name: image-list
+        configMap:
+          name: {{ .Name }}
+      {{ if .Secret }}
+      - name: pull-secret
+        secret:
+          secretName: {{ .Secret }}
+      {{ end }}

--- a/deploy/flavor.go
+++ b/deploy/flavor.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"slices"
+)
+
+type k8sFlavorType string
+
+func (k *k8sFlavorType) UnmarshalText(text []byte) error {
+	if slices.Contains(allFlavors, string(text)) {
+		*k = k8sFlavorType(text)
+		return nil
+	}
+	return fmt.Errorf("unknown k8s flavor %q", text)
+}
+
+func (k *k8sFlavorType) MarshalText() (text []byte, err error) {
+	return []byte(*k), nil
+}
+
+func flavor(flavor string) *k8sFlavorType {
+	var f k8sFlavorType
+	if err := f.UnmarshalText([]byte(flavor)); err != nil {
+		log.Fatal(err)
+	}
+	return &f
+}

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -1,0 +1,22 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+var debug bool
+
+func GetLogger() *slog.Logger {
+	opts := &slog.HandlerOptions{AddSource: true}
+	if debug {
+		opts.Level = slog.LevelDebug
+	}
+	return slog.New(slog.NewTextHandler(os.Stderr, opts))
+}
+
+func AddFlags(flags *pflag.FlagSet) {
+	flags.BoolVar(&debug, "debug", false, "Whether to enable debug logging.")
+}


### PR DESCRIPTION
- change deploy tool to use the flag package where appropriate rather than positional arguments for everything, as they would become a mess when another is added,
- rename daemonSetTemplate to deploymentTemplate as it already contains more than the daemonset, and will continue to grow soon,
- rename some variables to mention CRI to make room for an upcoming non-cri client/connection,
- extract a logging package, to be used in upcoming subcommand,
- in README and GHA workflow, correct deploy tool usage
- in README, mention daemonset in individual commands,
- use consistent indentation in the deployment template
- build the deploy tool just once in GH action