### PR TITLE
Use new functional options for backoff.

### DIFF
--- a/internal/metrics/submitter/submitter.go
+++ b/internal/metrics/submitter/submitter.go
@@ -78,9 +78,9 @@ func (s *Submitter) Run(ctx context.Context) (err error) {
 // newTicker returns a ticker that ticks once immediately, and then backs off exponentially forever.
 // Caller is responsible for calling Stop() on it eventually.
 func newTicker(ctx context.Context, timer backoff.Timer) *backoff.Ticker {
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = 10 * time.Second
-	b.MaxElapsedTime = 0
+	b := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(10*time.Second),
+		backoff.WithMaxElapsedTime(0))
 	return backoff.NewTickerWithTimer(backoff.WithContext(b, ctx), timer)
 }
 


### PR DESCRIPTION
I find it a bit more readable.
Introduced in https://github.com/cenkalti/backoff/pull/137