### PR TITLE
ROX-25992: Add multiarch builds to CI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,6 +16,12 @@ updates:
       k8s.io:
         patterns:
           - "k8s.io/*"
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'tuesday'
+    open-pull-requests-limit: 5
   - package-ecosystem: 'gomod'
     directory: '/deploy/tools'
     schedule:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,9 @@ jobs:
         with:
           directory: manifests
 
+      - name: Build binary
+        run: CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' .
+
       - name: Login to Quay
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
           directory: manifests
 
       - name: Build binary
-        run: CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' .
+        run: make binary
 
       - name: Login to Quay
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,9 +70,6 @@ jobs:
         with:
           directory: manifests
 
-      - name: Build binary
-        run: CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' .
-
       - name: Login to Quay
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -81,11 +78,18 @@ jobs:
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push OCI image
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64, linux/arm64, linux/s390x, linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.22.0 AS build
 WORKDIR /build
 COPY ./ ./
 RUN go mod verify
-RUN CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' .
+RUN make binary
 
 FROM scratch
 COPY --from=build /build/image-prefetcher /image-prefetcher

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest AS build
+FROM golang:1.22.0 AS build
 WORKDIR /build
 COPY ./ ./
 RUN go mod verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.22.0 AS build
 WORKDIR /build
 COPY ./ ./
-RUN go mod verify
 RUN make binary
 
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+FROM golang:latest AS build
+WORKDIR /build
+COPY ./ ./
+RUN go mod verify
+RUN CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' .
+
 FROM scratch
-COPY image-prefetcher /
+COPY --from=build /build/image-prefetcher /image-prefetcher
 ENTRYPOINT ["/image-prefetcher"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+binary:
+	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' .


### PR DESCRIPTION
Adds multi-arch builds for: ppc64le, s390x, and arm64
Summary of changes

- Moves building the binary to inside the dockerfile
- changes github actions to build multi-arch images via dockerx/qemu