### PR TITLE
fix: add missing lib.sh

### DIFF
--- a/scripts/fixxxer.sh
+++ b/scripts/fixxxer.sh
@@ -2,13 +2,10 @@
 # This script is an entrypoint for the action .github/workflows/fixxxer.yaml
 set -euo pipefail
 
+source scripts/lib.sh
+
 msg_file=$(mktemp)
 trap 'rm -f "${msg_file}"' EXIT
-
-function info()
-{
-  echo >&2 "$(date --iso-8601=seconds)" "$@"
-}
 
 find scripts/fixxxers -name '*.sh' -type f -printf "%p\n" | sort | while read -r script; do
     info "Running $script..."

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,0 +1,4 @@
+function info()
+{
+  echo >&2 "$(date --iso-8601=seconds)" "$@"
+}


### PR DESCRIPTION
The problem was:

```
Run ./scripts/fixxxer.sh
2025-0[4](https://github.com/stackrox/image-prefetcher/actions/runs/14746706501/job/41395320094#step:9:5)-30T04:27:42+00:00 Running scripts/fixxxers/10-deps-go-mod-tidy.sh...
2025-04-30T04:27:42+00:00 Script scripts/fixxxers/10-deps-go-mod-tidy.sh failed:
Running scripts/fixxxers/10-deps-go-mod-tidy.sh

./scripts/fixxxers/10-deps-go-mod-tidy.sh: line 4: scripts/lib.sh: No such file or directory
Error: Process completed with exit code 1.
```

This time I actually tested it works 🤦🏻 
```
[image-prefetcher]$ ./scripts/fixxxer.sh 
2025-04-30T06:32:20+02:00 Running scripts/fixxxers/10-deps-go-mod-tidy.sh...
2025-04-30T06:32:21+02:00 Committing changes made by scripts/fixxxers/10-deps-go-mod-tidy.sh
Global rh-pre-commit.....................................................Passed
[porridge/fix-fixer 96f745a] Running scripts/fixxxers/10-deps-go-mod-tidy.sh
 2 files changed, 8 insertions(+), 1 deletion(-)
[image-prefetcher]$ 
```
