### PR TITLE
fix: use distro-based images for credential plugin integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,8 @@ jobs:
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
+      # Distro-less "FROM scratch" images.
+
       - name: Prepare manifest OCI metadata for amd64
         id: meta-amd64
         uses: docker/metadata-action@v6
@@ -204,6 +206,149 @@ jobs:
             docker manifest push "${tag}"
           done
 
+      # Distro-full "FROM debian:stable-slim" images.
+
+      - name: Prepare manifest OCI metadata for amd64 - distro
+        id: meta-amd64-distro
+        uses: docker/metadata-action@v6
+        with:
+          images: "quay.io/stackrox-io/image-prefetcher"
+          # generate Docker tags based on the following events/attributes
+          # See https://github.com/docker/metadata-action
+          flavor: suffix=-distro-amd64,onlatest=true
+          tags: |
+            type=ref,event=branch,prefix=branch-
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=sha
+
+      - name: Build and push OCI amd64 image - distro
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-amd64-distro.outputs.tags }}
+          labels: ${{ steps.meta-amd64-distro.outputs.labels }}
+          platforms: linux/amd64
+          build-args: |
+            ARCH=amd64
+            BASE=debian:stable-slim
+
+      - name: Prepare manifest OCI metadata for arm64 - distro
+        id: meta-arm64-distro
+        uses: docker/metadata-action@v6
+        with:
+          images: "quay.io/stackrox-io/image-prefetcher"
+          # generate Docker tags based on the following events/attributes
+          # See https://github.com/docker/metadata-action
+          flavor: suffix=-distro-arm64,onlatest=true
+          tags: |
+            type=ref,event=branch,prefix=branch-
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=sha
+
+      - name: Build and push OCI arm64 image - distro
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-arm64-distro.outputs.tags }}
+          labels: ${{ steps.meta-arm64-distro.outputs.labels }}
+          platforms: linux/arm64
+          build-args: |
+            ARCH=arm64
+            BASE=debian:stable-slim
+
+      - name: Prepare manifest OCI metadata for ppc64le - distro
+        id: meta-ppc64le-distro
+        uses: docker/metadata-action@v6
+        with:
+          images: "quay.io/stackrox-io/image-prefetcher"
+          # generate Docker tags based on the following events/attributes
+          # See https://github.com/docker/metadata-action
+          flavor: suffix=-distro-ppc64le,onlatest=true
+          tags: |
+            type=ref,event=branch,prefix=branch-
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=sha
+
+      - name: Build and push OCI ppc64le image - distro
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-ppc64le-distro.outputs.tags }}
+          labels: ${{ steps.meta-ppc64le-distro.outputs.labels }}
+          platforms: linux/ppc64le
+          build-args: |
+            ARCH=ppc64le
+            BASE=debian:stable-slim
+
+      - name: Prepare manifest OCI metadata for s390x - distro
+        id: meta-s390x-distro
+        uses: docker/metadata-action@v6
+        with:
+          images: "quay.io/stackrox-io/image-prefetcher"
+          # generate Docker tags based on the following events/attributes
+          # See https://github.com/docker/metadata-action
+          flavor: suffix=-distro-s390x,onlatest=true
+          tags: |
+            type=ref,event=branch,prefix=branch-
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=sha
+
+      - name: Build and push OCI s390x image - distro
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-s390x-distro.outputs.tags }}
+          labels: ${{ steps.meta-s390x-distro.outputs.labels }}
+          platforms: linux/s390x
+          build-args: |
+            ARCH=s390x
+            BASE=debian:stable-slim
+
+      - name: Prepare manifest OCI metadata - distro
+        id: meta-distro
+        uses: docker/metadata-action@v6
+        with:
+          images: "quay.io/stackrox-io/image-prefetcher"
+          # generate Docker tags based on the following events/attributes
+          # See https://github.com/docker/metadata-action
+          flavor: suffix=-distro
+          tags: |
+            type=ref,event=branch,prefix=branch-
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=sha
+
+      - name: Create and push multi-arch manifest - distro
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_TAGS: ${{ steps.meta-distro.outputs.tags }}
+        run: |
+          for tag in ${IMAGE_TAGS};
+          do
+            docker manifest create "${tag}" \
+              --amend "${tag}-amd64" \
+              --amend "${tag}-arm64" \
+              --amend "${tag}-ppc64le" \
+              --amend "${tag}-s390x"
+            docker manifest push "${tag}"
+          done
 
   e2e:
     if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch
+ARG BASE=scratch
+FROM $BASE
 ARG ARCH=amd64
 COPY ./image-prefetcher-${ARCH} /image-prefetcher
 ENTRYPOINT ["/image-prefetcher"]

--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ It also optionally collects each pull attempt's duration and result.
      Plugin credentials fetched dynamically and tried for the images configured in the `CredentialProviderConfig` before pull secrets.
      Currently only supports mode `GKE`, which uses `/etc/srv/kubernetes/cri_auth_config.yaml` and `/home/kubernetes/bin` mounted from the host.
 
-   Example:
+     Note that in this case, the tool uses distro-based prefetcher images, to provide the dynamic
+     linker and shared libraries that a credential plugin binary might need.
 
+   Example:
+  
    ```
    go run github.com/stackrox/image-prefetcher/deploy@v0.3.0 --version v0.3.0 --namespace prefetch-images my-images > manifest.yaml
    ```

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -56,18 +56,22 @@ func init() {
 // processVersion processes the version string and returns the appropriate format.
 // For versions with dashes containing SHA (like v0.4.2-0.20251126115717-559dd9fd402f),
 // extracts short SHA and returns "sha-<shortSHA>" as long as the sha is at least 7 chars long.
-// Otherwise, returns as is
-func processVersion(version string) string {
+// Otherwise, returns as is.
+// If distro is true, appends "-distro" to the result.
+func processVersion(version string, distro bool) string {
+	result := version
 	// Pattern: vX.Y.Z-0.timestamp-SHA produced by `go mod tidy`.
 	dashRegex := regexp.MustCompile(`^v\d+\.\d+\.\d+-\d+\.\d+-([a-f0-9]+)$`)
 	matches := dashRegex.FindStringSubmatch(version)
-	if len(matches) != 2 {
-		return version
+	if len(matches) == 2 {
+		if fullSHA := matches[1]; len(fullSHA) >= 7 {
+			result = fmt.Sprintf("sha-%s", fullSHA[:7])
+		}
 	}
-	if fullSHA := matches[1]; len(fullSHA) >= 7 {
-		return fmt.Sprintf("sha-%s", fullSHA[:7])
+	if distro {
+		result += "-distro"
 	}
-	return version
+	return result
 }
 
 func main() {
@@ -84,7 +88,7 @@ func main() {
 		Name:                                 name,
 		Namespace:                            namespace,
 		Image:                                imageRepo,
-		Version:                              processVersion(version),
+		Version:                              processVersion(version, useKubeletImageCredentialIntegration != ""),
 		Secret:                               secret,
 		IsCRIO:                               isOcp,
 		NeedsPrivileged:                      isOcp,

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -12,15 +12,15 @@ import (
 )
 
 type settings struct {
-	Name                                  string
-	Namespace                             string
-	Image                                 string
-	Version                               string
-	Secret                                string
-	IsCRIO                                bool
-	NeedsPrivileged                       bool
-	CollectMetrics                        bool
-	UseKubeletImageCredentialIntegration  string
+	Name                                 string
+	Namespace                            string
+	Image                                string
+	Version                              string
+	Secret                               string
+	IsCRIO                               bool
+	NeedsPrivileged                      bool
+	CollectMetrics                       bool
+	UseKubeletImageCredentialIntegration string
 }
 
 const (

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -57,8 +57,8 @@ func init() {
 // For versions with dashes containing SHA (like v0.4.2-0.20251126115717-559dd9fd402f),
 // extracts short SHA and returns "sha-<shortSHA>" as long as the sha is at least 7 chars long.
 // Otherwise, returns as is.
-// If distro is true, appends "-distro" to the result.
-func processVersion(version string, distro bool) string {
+// If useDistroImage is true, appends "-distro" to the result.
+func processVersion(version string, useDistroImage bool) string {
 	result := version
 	// Pattern: vX.Y.Z-0.timestamp-SHA produced by `go mod tidy`.
 	dashRegex := regexp.MustCompile(`^v\d+\.\d+\.\d+-\d+\.\d+-([a-f0-9]+)$`)
@@ -68,7 +68,7 @@ func processVersion(version string, distro bool) string {
 			result = fmt.Sprintf("sha-%s", fullSHA[:7])
 		}
 	}
-	if distro {
+	if useDistroImage {
 		result += "-distro"
 	}
 	return result

--- a/internal/credentialprovider/plugin.go
+++ b/internal/credentialprovider/plugin.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	supportedResponseAPIVersion = "credentialprovider.kubelet.k8s.io/v1"
-	supportedConfigApiVersion   = "kubelet.config.k8s.io/v1"
+	supportedConfigAPIVersion   = "kubelet.config.k8s.io/v1"
 )
 
 // Minimal mirrors of k8s.io/kubelet/config/v1.CredentialProviderConfig to avoid depending on k8s.io/kubernetes.
@@ -101,8 +101,8 @@ func readCredentialProviderConfig(configPath string) (*credentialProviderConfig,
 		return nil, fmt.Errorf("unexpected kind %q, expected CredentialProviderConfig", config.Kind)
 	}
 
-	if config.APIVersion != supportedConfigApiVersion {
-		return nil, fmt.Errorf("unexpected API version %q, expected %q", config.APIVersion, supportedConfigApiVersion)
+	if config.APIVersion != supportedConfigAPIVersion {
+		return nil, fmt.Errorf("unexpected API version %q, expected %q", config.APIVersion, supportedConfigAPIVersion)
 	}
 
 	return &config, nil

--- a/internal/credentialprovider/plugin.go
+++ b/internal/credentialprovider/plugin.go
@@ -119,7 +119,7 @@ func (kr *PluginKeyring) LookupWithCtx(ctx context.Context, image string) ([]Aut
 		return nil, false
 	}
 
-	var allCreds []AuthConfig
+	dk := &BasicDockerKeyring{}
 	for _, provider := range kr.providers {
 		if !kr.matchesImage(provider.matchImages, image) {
 			continue
@@ -131,15 +131,10 @@ func (kr *PluginKeyring) LookupWithCtx(ctx context.Context, image string) ([]Aut
 			kr.logger.Warn("credential provider plugin failed", "plugin", provider.name, "image", image, "error", err)
 			continue
 		}
-
-		allCreds = append(allCreds, creds...)
+		dk.Add(creds)
 	}
 
-	if len(allCreds) > 0 {
-		return allCreds, true
-	}
-
-	return nil, false
+	return dk.Lookup(image)
 }
 
 // matchesImage checks if any of the match patterns match the given image.
@@ -154,7 +149,7 @@ func (kr *PluginKeyring) matchesImage(patterns []string, image string) bool {
 }
 
 // execPlugin executes the credential provider plugin and parses the response.
-func (kr *PluginKeyring) execPlugin(ctx context.Context, provider pluginProviderWrapper, image string) ([]AuthConfig, error) {
+func (kr *PluginKeyring) execPlugin(ctx context.Context, provider pluginProviderWrapper, image string) (DockerConfig, error) {
 	// Prepare the request
 	request := credentialproviderv1.CredentialProviderRequest{
 		Image: image,
@@ -188,16 +183,13 @@ func (kr *PluginKeyring) execPlugin(ctx context.Context, provider pluginProvider
 		return nil, fmt.Errorf("apiVersion from credential plugin response did not match expected apiVersion:%s, actual apiVersion:%s", supportedResponseAPIVersion, response.APIVersion)
 	}
 
-	// Convert to AuthConfig
-	var creds []AuthConfig
-	for registry, authConfig := range response.Auth {
-		creds = append(creds, AuthConfig{
-			Username:      authConfig.Username,
-			Password:      authConfig.Password,
-			ServerAddress: registry,
-		})
+	kr.logger.Debug("received credentials from plugin", "plugin", provider.name, "count", len(response.Auth))
+	dockerConfig := make(DockerConfig, len(response.Auth))
+	for matchImage, authConfig := range response.Auth {
+		dockerConfig[matchImage] = DockerConfigEntry{
+			Username: authConfig.Username,
+			Password: authConfig.Password,
+		}
 	}
-
-	kr.logger.Debug("received credentials from plugin", "plugin", provider.name, "count", len(creds))
-	return creds, nil
+	return dockerConfig, nil
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -78,7 +78,7 @@ func Run(logger *slog.Logger, criSocketPath string, dockerConfigJSONPath string,
 				},
 				Auth: auth,
 			}
-			go pullImageWithRetries(ctx, logger.With("image", imageName, "authNum", i), &wg, criClient, metricsSink.Chan(), imageName, request, timing, &results)
+			go pullImageWithRetries(ctx, logger.With("image", imageName, "authNum", i, "authServer", auth.ServerAddress, "authUsername", auth.Username), &wg, criClient, metricsSink.Chan(), imageName, request, timing, &results)
 		}
 	}
 	wg.Wait()
@@ -141,9 +141,8 @@ func getAuthsForImage(ctx context.Context, logger *slog.Logger, pluginKr *creden
 			logger.DebugContext(ctx, "got credentials from plugin", "image", imageName, "count", len(pluginCreds))
 			for _, creds := range pluginCreds {
 				auth := &criV1.AuthConfig{
-					Username:      creds.Username,
-					Password:      creds.Password,
-					ServerAddress: creds.ServerAddress,
+					Username: creds.Username,
+					Password: creds.Password,
 				}
 				auths = append(auths, auth)
 			}


### PR DESCRIPTION
## Why

- Turns out that https://github.com/stackrox/image-prefetcher/pull/184 never actually worked in practice, since the `FROM scratch` image does not contain libraries that the GKE credential plugin needs: `plugin execution failed: fork/exec /tmp/credential-provider-bin/auth-provider-gcp: no such file or directory, stderr: `
- Looks like the testing done for the above PR in https://github.com/stackrox/stackrox/pull/19287 where the [`gke-latest-...` job succeeded](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/19287/pull-ci-stackrox-stackrox-master-gke-latest-qa-e2e-tests/2044050064023752704) must have been some kind of fluke 🤷🏻 In fact that problematic test case didn't seem to run at all:
  ```
  15:10:32 | INFO  | ImageScanningTest         | Starting testcase: Image metadata from registry test - quay-auto
  15:10:32 | INFO  | Helpers                   | Won't collect logs for: org.opentest4j.TestAbortedException: Ignored via @IgnoreIf
  15:10:32 | INFO  | ImageScanningTest         | Post test cleanup:
  15:10:32 | INFO  | ImageScanningTest         | Ending testcase
  ```

## What this does

- This PR adds a parallel set of images differing only in base image, they are about twice the size of the `FROM scratch` ones. It also changes the deploy tool to use them transparently when credential plugin integration is enabled.
  <img width="949" height="605" alt="image" src="https://github.com/user-attachments/assets/9e1aea69-2fa9-4e7f-a34e-a9ebd0cb2d33" />

- Additionally, it changes the auth data passing to resemble the way kubelet does it more - in particular it drops the server endpoint piece which somehow prevents CRI from fetching the image:

  ```
  msg="image failed to pull" image=us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12 authNum=3
  error="rpc error: code = Unknown desc = failed to pull and unpack image \"us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12\": failed to resolve reference \"us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12\": failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://us.gcr.io/v2/token?scope=repository%3Aacs-san-stackroxci%2Fqa-multi-arch%3Apull&scope=repository%3Aacs-san-stackroxci%2Fus.gcr.io%2Fqa-multi-arch%3Apull&service=us.gcr.io: 403 Forbidden"
  ```

## Testing

- This time tested for realz in https://github.com/stackrox/stackrox/pull/20378:
```
time=2026-05-06T13:11:41.995Z level=INFO source=/home/runner/work/image-prefetcher/image-prefetcher/internal/main.go:187 msg="image pulled successfully" image=us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12 authNum=0 authServer="" authUsername=_token response="image_ref:\"sha256:4037a5562b030fd80ec889bb885405587a52cfef898ffb7402649005dfda75ff\"" elapsed=28.646953919s
time=2026-05-06T13:11:50.222Z level=INFO source=/home/runner/work/image-prefetcher/image-prefetcher/internal/main.go:187 msg="image pulled successfully" image=us.gcr.io/acs-san-stackroxci/qa/registry-image:0.3 authNum=1 authServer="" authUsername=_token response="image_ref:\"sha256:e03ee8c409b34496c09c261194dd3d0d825f0a67350d49c8812d7dd65a95dfdc\"" elapsed=36.874397134s
```