### PR TITLE
feat: add OCP modes for kubelet credential provider integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,7 +206,8 @@ jobs:
             docker manifest push "${tag}"
           done
 
-      # Distro-full "FROM debian:stable-slim" images.
+      # Distro-full "UBI-based" images.
+      # These are 10 MiB larger than debian -slim images but already contain CA certificates.
 
       - name: Prepare manifest OCI metadata for amd64 - distro
         id: meta-amd64-distro
@@ -234,7 +235,7 @@ jobs:
           platforms: linux/amd64
           build-args: |
             ARCH=amd64
-            BASE=debian:stable-slim
+            BASE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
       - name: Prepare manifest OCI metadata for arm64 - distro
         id: meta-arm64-distro
@@ -262,7 +263,7 @@ jobs:
           platforms: linux/arm64
           build-args: |
             ARCH=arm64
-            BASE=debian:stable-slim
+            BASE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
       - name: Prepare manifest OCI metadata for ppc64le - distro
         id: meta-ppc64le-distro
@@ -290,7 +291,7 @@ jobs:
           platforms: linux/ppc64le
           build-args: |
             ARCH=ppc64le
-            BASE=debian:stable-slim
+            BASE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
       - name: Prepare manifest OCI metadata for s390x - distro
         id: meta-s390x-distro
@@ -318,7 +319,7 @@ jobs:
           platforms: linux/s390x
           build-args: |
             ARCH=s390x
-            BASE=debian:stable-slim
+            BASE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
       - name: Prepare manifest OCI metadata - distro
         id: meta-distro

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ It also optionally collects each pull attempt's duration and result.
    - `--collect-metrics`: if the image pull metrics should be collected.
    - `--use-kubelet-image-credential-integration=MODE`: enables kubelet [credential provider](https://kubernetes.io/blog/2022/12/22/kubelet-credential-providers/) plugin integration.
      Plugin credentials fetched dynamically and tried for the images configured in the `CredentialProviderConfig` before pull secrets.
-     Currently only supports mode `GKE`, which uses `/etc/srv/kubernetes/cri_auth_config.yaml` and `/home/kubernetes/bin` mounted from the host.
-
      Note that in this case, the tool uses distro-based prefetcher images, to provide the dynamic
      linker and shared libraries that a credential plugin binary might need.
+     Currently supported modes are:
+       - `GKE`, which uses `/etc/srv/kubernetes/cri_auth_config.yaml` and `/home/kubernetes/bin` mounted from the host.
+       - `OCP`, which uses `/etc/kubernetes/credential-providers/` and `/usr/libexec/kubelet-image-credential-provider-plugins` mounted from the host.
 
    Example:
   

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ It also optionally collects each pull attempt's duration and result.
      linker and shared libraries that a credential plugin binary might need.
      Currently supported modes are:
        - `GKE`, which uses `/etc/srv/kubernetes/cri_auth_config.yaml` and `/home/kubernetes/bin` mounted from the host.
-       - `OCP`, which uses `/etc/kubernetes/credential-providers/` and `/usr/libexec/kubelet-image-credential-provider-plugins` mounted from the host.
+       - `OCP-GCR`, `OCP-ECR`, `OCP-ACR`, for OCP on GCP, AWS, and Azure respectively.
+         These use the corresponding credential provider config from `/etc/kubernetes/credential-providers/` and binaries from `/usr/libexec/kubelet-image-credential-provider-plugins` mounted from the host.
 
    Example:
   

--- a/deploy/deployment.yaml.gotpl
+++ b/deploy/deployment.yaml.gotpl
@@ -167,6 +167,10 @@ spec:
         - "--image-credential-provider-config=/tmp/credential-provider/cri_auth_config.yaml"
         - "--image-credential-provider-bin-dir=/tmp/credential-provider-bin"
         {{ end }}
+        {{ if eq .UseKubeletImageCredentialIntegration "OCP" }}
+        - "--image-credential-provider-config=/tmp/credential-provider/generic-credential-provider.yaml"
+        - "--image-credential-provider-bin-dir=/tmp/credential-provider-bin"
+        {{ end }}
         env:
         - name: NODE_NAME
           valueFrom:
@@ -193,7 +197,7 @@ spec:
           name: pull-secret
           readOnly: true
         {{ end }}
-        {{ if eq .UseKubeletImageCredentialIntegration "GKE" }}
+        {{ if or (eq .UseKubeletImageCredentialIntegration "GKE") (eq .UseKubeletImageCredentialIntegration "OCP")}}
         - mountPath: /tmp/credential-provider
           name: credential-provider-config
           readOnly: true
@@ -245,5 +249,15 @@ spec:
       - name: credential-provider-bin
         hostPath:
           path: /home/kubernetes/bin
+          type: Directory
+      {{ end }}
+      {{ if eq .UseKubeletImageCredentialIntegration "OCP" }}
+      - name: credential-provider-config
+        hostPath:
+          path: /etc/kubernetes/credential-providers
+          type: Directory
+      - name: credential-provider-bin
+        hostPath:
+          path: /usr/libexec/kubelet-image-credential-provider-plugins
           type: Directory
       {{ end }}

--- a/deploy/deployment.yaml.gotpl
+++ b/deploy/deployment.yaml.gotpl
@@ -129,6 +129,7 @@ metadata:
     ignore-check.kube-linter.io/privilege-escalation-container: "Needs access to CRI socket."
     ignore-check.kube-linter.io/privileged-container: "Needs access to CRI socket."
     ignore-check.kube-linter.io/run-as-non-root: "Needs access to CRI socket."
+    ignore-check.kube-linter.io/host-network: "Credential provider plugins may need host network access."
 spec:
   selector:
     matchLabels:
@@ -142,7 +143,9 @@ spec:
         openshift.io/required-scc: privileged
       {{ end }}
     spec:
+      {{ if .UseKubeletImageCredentialIntegration }}
       hostNetwork: true
+      {{ end }}
       serviceAccountName: {{ .Name }}
       tolerations:
       # Broad toleration to match stackrox collector.

--- a/deploy/deployment.yaml.gotpl
+++ b/deploy/deployment.yaml.gotpl
@@ -167,8 +167,16 @@ spec:
         - "--image-credential-provider-config=/tmp/credential-provider/cri_auth_config.yaml"
         - "--image-credential-provider-bin-dir=/tmp/credential-provider-bin"
         {{ end }}
-        {{ if eq .UseKubeletImageCredentialIntegration "OCP" }}
-        - "--image-credential-provider-config=/tmp/credential-provider/generic-credential-provider.yaml"
+        {{ if eq .UseKubeletImageCredentialIntegration "OCP-GCR" }}
+        - "--image-credential-provider-config=/tmp/credential-provider/gcr-credential-provider.yaml"
+        - "--image-credential-provider-bin-dir=/tmp/credential-provider-bin"
+        {{ end }}
+        {{ if eq .UseKubeletImageCredentialIntegration "OCP-ECR" }}
+        - "--image-credential-provider-config=/tmp/credential-provider/ecr-credential-provider.yaml"
+        - "--image-credential-provider-bin-dir=/tmp/credential-provider-bin"
+        {{ end }}
+        {{ if eq .UseKubeletImageCredentialIntegration "OCP-ACR" }}
+        - "--image-credential-provider-config=/tmp/credential-provider/acr-credential-provider.yaml"
         - "--image-credential-provider-bin-dir=/tmp/credential-provider-bin"
         {{ end }}
         env:
@@ -197,7 +205,7 @@ spec:
           name: pull-secret
           readOnly: true
         {{ end }}
-        {{ if or (eq .UseKubeletImageCredentialIntegration "GKE") (eq .UseKubeletImageCredentialIntegration "OCP")}}
+        {{ if or (eq .UseKubeletImageCredentialIntegration "GKE") (eq .UseKubeletImageCredentialIntegration "OCP-GCR") (eq .UseKubeletImageCredentialIntegration "OCP-ECR") (eq .UseKubeletImageCredentialIntegration "OCP-ACR")}}
         - mountPath: /tmp/credential-provider
           name: credential-provider-config
           readOnly: true
@@ -251,7 +259,7 @@ spec:
           path: /home/kubernetes/bin
           type: Directory
       {{ end }}
-      {{ if eq .UseKubeletImageCredentialIntegration "OCP" }}
+      {{ if or (eq .UseKubeletImageCredentialIntegration "OCP-GCR") (eq .UseKubeletImageCredentialIntegration "OCP-ECR") (eq .UseKubeletImageCredentialIntegration "OCP-ACR") }}
       - name: credential-provider-config
         hostPath:
           path: /etc/kubernetes/credential-providers

--- a/deploy/deployment.yaml.gotpl
+++ b/deploy/deployment.yaml.gotpl
@@ -142,6 +142,7 @@ spec:
         openshift.io/required-scc: privileged
       {{ end }}
     spec:
+      hostNetwork: true
       serviceAccountName: {{ .Name }}
       tolerations:
       # Broad toleration to match stackrox collector.

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -50,7 +50,7 @@ func init() {
 	flag.TextVar(&k8sFlavor, "k8s-flavor", flavor(vanillaFlavor), fmt.Sprintf("Kubernetes flavor. Accepted values: %s", strings.Join(allFlavors, ",")))
 	flag.StringVar(&secret, "secret", "", "Kubernetes image pull Secret to use when pulling.")
 	flag.BoolVar(&collectMetrics, "collect-metrics", false, "Whether to collect and expose image pull metrics.")
-	flag.StringVar(&useKubeletImageCredentialIntegration, "use-kubelet-image-credential-integration", "", "Enable kubelet image credential provider plugin integration. Accepted values: GKE, OCP.")
+	flag.StringVar(&useKubeletImageCredentialIntegration, "use-kubelet-image-credential-integration", "", "Enable kubelet image credential provider plugin integration. Accepted values: GKE, OCP-GCR, OCP-ECR, OCP-ACR.")
 }
 
 // processVersion processes the version string and returns the appropriate format.

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -50,7 +50,7 @@ func init() {
 	flag.TextVar(&k8sFlavor, "k8s-flavor", flavor(vanillaFlavor), fmt.Sprintf("Kubernetes flavor. Accepted values: %s", strings.Join(allFlavors, ",")))
 	flag.StringVar(&secret, "secret", "", "Kubernetes image pull Secret to use when pulling.")
 	flag.BoolVar(&collectMetrics, "collect-metrics", false, "Whether to collect and expose image pull metrics.")
-	flag.StringVar(&useKubeletImageCredentialIntegration, "use-kubelet-image-credential-integration", "", "Enable kubelet image credential provider plugin integration. Accepted values: GKE")
+	flag.StringVar(&useKubeletImageCredentialIntegration, "use-kubelet-image-credential-integration", "", "Enable kubelet image credential provider plugin integration. Accepted values: GKE, OCP.")
 }
 
 // processVersion processes the version string and returns the appropriate format.


### PR DESCRIPTION
## Summary
- Add `OCP-GCR`, `OCP-ECR`, `OCP-ACR` as supported modes for `--use-kubelet-image-credential-integration`, for OCP clusters on GCP, AWS, and Azure respectively.
- Each mode uses the corresponding cloud-specific credential provider config (`gcr-credential-provider.yaml`, `ecr-credential-provider.yaml`, `acr-credential-provider.yaml`) from `/etc/kubernetes/credential-providers/` and binaries from `/usr/libexec/kubelet-image-credential-provider-plugins`, matching the paths used by the [OpenShift machine-config-operator](https://github.com/openshift/machine-config-operator/blob/108a4065c038c6707a71e87ec694e144fcc2c378/pkg/controller/template/render.go#L365-L377).
- Switch to host networking, necessary for connection to Instance MetaData Service on AWS: **this breaks metrics submission** since metrics service DNS name no longer resolves
- Switch to UBI-based images that contain CA certificates, necessary for the AWS plugin to talk to some AWS service

## Test plan
- [x] Deployed on an OCP/GCP cluster with `OCP-GCR` mode — volume mounts work, credential provider plugin initializes successfully (1 plugin loaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)