### PR TITLE
fix: handle nil auth when pulling unauthenticated images

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -78,7 +78,7 @@ func Run(logger *slog.Logger, criSocketPath string, dockerConfigJSONPath string,
 				},
 				Auth: auth,
 			}
-			go pullImageWithRetries(ctx, logger.With("image", imageName, "authNum", i, "authServer", auth.ServerAddress, "authUsername", auth.Username), &wg, criClient, metricsSink.Chan(), imageName, request, timing, &results)
+			go pullImageWithRetries(ctx, pullLogger(logger, imageName, i, auth), &wg, criClient, metricsSink.Chan(), imageName, request, timing, &results)
 		}
 	}
 	wg.Wait()
@@ -170,6 +170,13 @@ func getAuthsForImage(ctx context.Context, logger *slog.Logger, pluginKr *creden
 	}
 
 	return auths
+}
+
+func pullLogger(logger *slog.Logger, imageName string, authNum int, auth *criV1.AuthConfig) *slog.Logger {
+	if auth != nil {
+		return logger.With("image", imageName, "authNum", authNum, "authServer", auth.ServerAddress, "authUsername", auth.Username)
+	}
+	return logger.With("image", imageName, "authNum", authNum)
 }
 
 func pullImageWithRetries(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, client criV1.ImageServiceClient, metricsSink chan<- *metricsProto.Result, name string, request *criV1.PullImageRequest, timing TimingConfig, results *sync.Map) {


### PR DESCRIPTION
## Summary
- Fix nil pointer panic in `internal/main.go:81` when credential providers are configured but no credentials match the image being pulled (e.g. public images).
- `getAuthsForImage` intentionally returns a `nil` `AuthConfig` entry for unauthenticated pulls, but the logger call in `Run()` dereferenced it to extract `ServerAddress` and `Username`.
- Extract `pullLogger` helper that safely builds a logger for pull attempts, omitting auth fields when auth is nil.

## Test plan
- [x] Observed the panic on an OCP cluster when prefetching `docker.io/library/busybox` with credential provider integration enabled
- [x] `go build ./internal/` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)