### PR TITLE
fix: properly format credential plugin request

### DIFF
--- a/internal/credentialprovider/plugin.go
+++ b/internal/credentialprovider/plugin.go
@@ -11,6 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubelet/pkg/apis/credentialprovider/install"
 	credentialproviderv1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -46,6 +49,15 @@ type pluginProviderWrapper struct {
 	apiVersion  string
 	matchImages []string
 	args        []string
+}
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+func init() {
+	install.Install(scheme)
 }
 
 // NewPluginKeyring creates a new keyring that uses credential provider plugins.
@@ -148,13 +160,23 @@ func (kr *PluginKeyring) matchesImage(patterns []string, image string) bool {
 	return false
 }
 
-// execPlugin executes the credential provider plugin and parses the response.
+// marshalRequest serializes the request in a format which contains the required apiVersion and kind fields.
+func marshalRequest(request *credentialproviderv1.CredentialProviderRequest) ([]byte, error) {
+	jsonMediaType := "application/json"
+	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), jsonMediaType)
+	if !ok {
+		return nil, fmt.Errorf("unsupported media type %q", jsonMediaType)
+	}
+	return runtime.Encode(codecs.EncoderForVersion(info.Serializer, credentialproviderv1.SchemeGroupVersion), request)
+}
+
+// execPlugin executes the credential provider plugin and parses the responseFile.
 func (kr *PluginKeyring) execPlugin(ctx context.Context, provider pluginProviderWrapper, image string) (DockerConfig, error) {
 	// Prepare the request
 	request := credentialproviderv1.CredentialProviderRequest{
 		Image: image,
 	}
-	requestJSON, err := json.Marshal(request)
+	requestJSON, err := marshalRequest(&request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}

--- a/internal/credentialprovider/plugin_test.go
+++ b/internal/credentialprovider/plugin_test.go
@@ -1,0 +1,68 @@
+package credentialprovider
+
+import (
+	"github.com/neilotoole/slogt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestPluginKeyring_execPlugin(t *testing.T) {
+	tests := map[string]struct {
+		requestFile  string
+		responseFile string
+		exitCode     string
+
+		want    DockerConfig
+		wantErr bool
+	}{
+		"empty-success": {
+			requestFile:  "basic-request.json",
+			responseFile: "basic-response.json",
+			exitCode:     "0",
+
+			want: DockerConfig{
+				"foo": {
+					Username: "user",
+					Password: "not-a-secret",
+					Email:    "",
+					Provider: nil,
+				},
+			},
+			wantErr: false,
+		},
+		"empty-error": {
+			requestFile:  "basic-request.json",
+			responseFile: "basic-response.json",
+			exitCode:     "1",
+
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualRequestFile := path.Join(t.TempDir(), tt.requestFile)
+			provider := pluginProviderWrapper{
+				name:        "fake_plugin",
+				binPath:     "test_data/fake_plugin",
+				matchImages: []string{"*"},
+				// fake_plugin's args are: path to save stdin to, path to copy to stdout, exit code
+				args: []string{actualRequestFile, path.Join("test_data", tt.responseFile), tt.exitCode},
+			}
+			kr := &PluginKeyring{logger: slogt.New(t)}
+			got, err := kr.execPlugin(t.Context(), provider, "foo-image")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("execPlugin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			actualRequest, err := os.ReadFile(actualRequestFile)
+			require.NoError(t, err)
+			expectedRequest, err := os.ReadFile(path.Join("test_data", tt.requestFile))
+			require.NoError(t, err)
+			assert.Equal(t, string(expectedRequest), string(actualRequest))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/credentialprovider/test_data/basic-request.json
+++ b/internal/credentialprovider/test_data/basic-request.json
@@ -1,0 +1,1 @@
+{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1","image":"foo-image"}

--- a/internal/credentialprovider/test_data/basic-response.json
+++ b/internal/credentialprovider/test_data/basic-response.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "credentialprovider.kubelet.k8s.io/v1",
+  "kind": "CredentialProviderResponse",
+  "auth": {
+    "foo": {
+      "username": "user",
+      "password": "not-a-secret"
+    }
+  }
+}

--- a/internal/credentialprovider/test_data/fake_plugin
+++ b/internal/credentialprovider/test_data/fake_plugin
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+cat > "$1"
+cat "$2"
+exit "$3"

--- a/internal/credentialprovider/test_data/fake_plugin
+++ b/internal/credentialprovider/test_data/fake_plugin
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/sh
 cat > "$1"
 cat "$2"
 exit "$3"


### PR DESCRIPTION
`json.Marshal` does not produce the `apiVersion` and `kind` fields, required by the protocol and actually checked by the AWS ECR plugin, unlike the GKE one which happened to be more forgiving.

This uses the `k8s.io/apimachinery/pkg/runtime/serializer` package and adds a test.